### PR TITLE
[#2]Feature][custom exception 정의]

### DIFF
--- a/src/main/java/com/nbe8101team03/global/exception/errorCode/ErrorCode.java
+++ b/src/main/java/com/nbe8101team03/global/exception/errorCode/ErrorCode.java
@@ -1,0 +1,15 @@
+package com.nbe8101team03.global.exception.errorCode;
+
+import org.springframework.http.HttpStatus;
+
+/**
+ * 에러 코드에 대한 정의(인터페이스)입니다. 모든 custom exception 은 해당 예외를 정의하기 위해
+ * ErrorCode 를 상속받는 구현 enum 클래스를 만들어야 합니다.
+ */
+public interface ErrorCode {
+
+    HttpStatus getHttpStatus();
+
+    String getMessage();
+
+}

--- a/src/main/java/com/nbe8101team03/global/exception/errorCode/ProductErrorCode.java
+++ b/src/main/java/com/nbe8101team03/global/exception/errorCode/ProductErrorCode.java
@@ -1,0 +1,31 @@
+package com.nbe8101team03.global.exception.errorCode;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+
+/**
+ * error code 에 대한 예시 코드입니다. 해당 error code 를 사용하여 exception 을 정의할 수 있습니다.
+ */
+@RequiredArgsConstructor
+public enum ProductErrorCode implements ErrorCode {
+
+    UNKNOWN_PRODUCT(HttpStatus.NOT_FOUND, "해당 상품을 찾을 수 없습니다."),
+    MEMBER_WRITE_FAIL(HttpStatus.FORBIDDEN, "상품을 편집할 권한이 없습니다."),
+    READ_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "상품 정보를 불러올 수 없습니다.");
+
+
+    private final HttpStatus status;
+    private final String message;
+
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return status;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+}

--- a/src/main/java/com/nbe8101team03/global/exception/exception/BaseException.java
+++ b/src/main/java/com/nbe8101team03/global/exception/exception/BaseException.java
@@ -1,0 +1,48 @@
+package com.nbe8101team03.global.exception.exception;
+
+import com.nbe8101team03.global.exception.errorCode.ErrorCode;
+import lombok.Getter;
+
+/**
+ * 모든 custom 예외의 조상 예외 객체입니다. RuntimeException 을 직접적으로 상속받아 처리합니다.
+ * ErrorCode 와, 콘솔에 띄울 로그 메시지를 정의할 수 있습니다.
+ */
+@Getter
+public abstract class BaseException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+    private final String logMessage;
+
+    /**
+     * ErrorCode 만 받아 처리합니다. log message 가 누락되어 있습니다.
+     * @param errorCode 정의된 에러 코드
+     */
+    protected BaseException(ErrorCode errorCode) {
+        super(errorCode.getMessage(), null, false, false);
+        this.errorCode = errorCode;
+        this.logMessage = "[client] " + errorCode.getMessage();
+    }
+
+    /**
+     * ErrorCode 및 로그 메시지를 정의합니다.
+     * @param errorCode 정의된 에러 코드
+     * @param logMessage 콘솔에 띄울 메시지
+     */
+    protected BaseException(ErrorCode errorCode, String logMessage) {
+        super(errorCode.getMessage(), null, false, false);
+        this.errorCode = errorCode;
+        this.logMessage = "[log] " + logMessage;
+    }
+
+    /**
+     * ErrorCode 및 로그 메시지를 정의합니다.
+     * @param errorCode 정의된 에러 코드
+     * @param logMessage 콘솔에 띄울 메시지
+     * @param clientMessage 클라이언트에게 전송될 재정의된 메시지
+     */
+    protected BaseException(ErrorCode errorCode, String logMessage, String clientMessage) {
+        super(clientMessage, null, false, false);
+        this.errorCode = errorCode;
+        this.logMessage = "[log] " + logMessage;
+    }
+}

--- a/src/main/java/com/nbe8101team03/global/exception/exception/ProductException.java
+++ b/src/main/java/com/nbe8101team03/global/exception/exception/ProductException.java
@@ -1,0 +1,26 @@
+package com.nbe8101team03.global.exception.exception;
+
+import com.nbe8101team03.global.exception.errorCode.ProductErrorCode;
+
+/**
+ * 상품 관리 시 발생하는 예외를 정의하였습니다. 기존에 정의한 예외 코드를 사용하여, 예외를 구조화하고, 추후 exception handler
+ * 를 통해, 클라이언트로의 예외 메시지 구조를 정립하였습니다.
+ *
+ * @see BaseException
+ * @see ProductErrorCode
+ */
+public class ProductException extends BaseException {
+
+    public ProductException(ProductErrorCode code) {
+         super(code);
+    }
+
+    public ProductException(ProductErrorCode code, String logMessage) {
+        super(code, logMessage);
+    }
+
+    public ProductException(ProductErrorCode code, String logMessage, String clientMessage) {
+        super(code, logMessage, clientMessage);
+    }
+
+}

--- a/src/main/java/com/nbe8101team03/global/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/nbe8101team03/global/exception/handler/GlobalExceptionHandler.java
@@ -1,0 +1,37 @@
+package com.nbe8101team03.global.exception.handler;
+
+
+import com.nbe8101team03.global.exception.exception.BaseException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+/**
+ * 전역 예외 헨들러입니다. 코드에서 발생하는 예외가 클라이언트로 넘어가기 전, 예외를 잡아 적절한 형식을 가공합니다. <br>
+ * log message 표시 여부는 해당 클래스에서 지정합니다.
+ */
+@Slf4j
+@RestControllerAdvice
+@RequiredArgsConstructor
+public class GlobalExceptionHandler {
+
+    //todo: 추후 환경 변수 주입으로 변경
+    private boolean isDebug = true;
+
+    @ExceptionHandler(BaseException.class)
+    public ResponseEntity<Object> handleBaseException(BaseException exception) {
+
+        if(isDebug) {
+            log.warn("{}", exception.getLogMessage());
+        }
+
+        //todo: 추후 응답 형식 지정 이후 적절한 값으로 변경
+        return ResponseEntity.status(exception.getErrorCode().getHttpStatus())
+                .body(exception.getErrorCode());
+
+    }
+
+
+}


### PR DESCRIPTION
<!-- PR의 제목은 "[#이슈번호] [종류(ex.FEATURE)] 이슈이름" 으로 작성 -->

<!-- Auto close 할 이슈 번호 -->
- close #2

## ✨ 구현 기능 명세

전역 예외 처리기 및 커스텀 예외를 정의하였습니다. 
모든 custom exception 은 `BaseException` 을 상속하여야 합니다. `BaseException`은 그 생성자로
- ErrorCode
- logMessage
- clientMessage

를 받습니다. logMessage 및 clientMessage 는 각각 콘솔에 띄울 디버그용 메시지와, 서버에서 클라이언트로 표시할 메시지입니다. 

각 기능 당 그에 따른 `BaseException` 을 상속받는 커스텀 예외를 만들어야 됩니다. 예시로 작성한 `ProductException` 을 보겠습니다.

```java
public class ProductException extends BaseException {

    public ProductException(ProductErrorCode code) {
         super(code);
    }

    public ProductException(ProductErrorCode code, String logMessage) {
        super(code, logMessage);
    }

    public ProductException(ProductErrorCode code, String logMessage, String clientMessage) {
        super(code, logMessage, clientMessage);
    }

}
```
추후 기술될 `ProductErrorCode` 를 받는 생성자를 통해 예외를 만들어낼 수 있습니다.

---


`ErrorCode` 는 각 도메인에 따라 정의된, 세분화된 예외 코드입니다. 각 도메인에 따라 예외의 종류를 정의합니다. `ErrorCode` 자체는 인터페이스이며, 각 도메인에 맞게 구현 enum class 를 만들어야 합니다.
```java
@RequiredArgsConstructor
public enum ProductErrorCode implements ErrorCode {

    UNKNOWN_PRODUCT(HttpStatus.NOT_FOUND, "해당 상품을 찾을 수 없습니다."),
    MEMBER_WRITE_FAIL(HttpStatus.FORBIDDEN, "상품을 편집할 권한이 없습니다."),
    READ_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "상품 정보를 불러올 수 없습니다.");


    private final HttpStatus status;
    private final String message;


    @Override
    public HttpStatus getHttpStatus() {
        return status;
    }

    @Override
    public String getMessage() {
        return message;
    }
}
```

예시로 만든 `ProductErrorCode` 입니다. `UNKNOWN_PRODUCT` 는 DB 에서 검색하고자 하는 상품 정보를 찾을 수 없는 경우,`MEMBER_WRITE_FAIL` 은 admin 이 아닌 일반 유저가 product 에 대해 create, update, delete 를 시도하는 경우 발생합니다. `READ_FAIL` 은 상품 정보 읽기 중 원인을 알 수 없는 오류로 데이터를 불러오기 실패하는 경우입니다.

이처럼, 각 도메인에 맞는 ErrorCode 를 정의하고(`ProductErrorCode`) 기능을 구현하면서 발생하는 예외에 대해 `ProductExceptoin` 을 정의하여 
```java
throw new ProductException(ProductErrorCode.UNKNOWN_PRODUCT, "some log error");
```
 로 사용하면 됩니다.
 
 ---
 
 따라서, 추후 각자 도메인을 설계하고 구현하는 과정에서 본인이 개발하는 기능에 따라 BaseException 과 ErrorCode 를 상속받는 예외 클래스를 `/global/exception`  내에 만들어주시고, 사용하시면 됩니다. 가령,  orders 를 예시로 들자면,
 `OrderErrorCode` 를 먼저 정의한 뒤, 그 상황을 enum 을 통해 관리합니다. 이때, Http 상태 코드 및 클라이언트로 메시지를 보내는 default 값을 지정해야 합니다.
 
 가령, 특정 정보(ex: 주소지가 입력되지 않음)가 미포함된 데이터에 대해 저장을 시도한다면
 `ADDRESS_NOT_FOUND(HttpStatus.NOT_FOUND, "주소지가 입력되지 않았습니다")` 와 같은 내용을 넣을 수 있습니다.
 
 이를 토대로 `OrderException extends BaseException` 을 를 구현하여, 3개의 생성자
- OrderErrorCode 만 받는 생성자
- OrderErrorCode, logMessage 를 받는 생성자
- OrderErrorCode, logMessage, clientMessage 를 받는 생성자
를 정의합니다.
클라이언트 메시지의 경우, 명시하지 않으면 ErrorCode 에서 정의한 값이 넘어가고, 예외를 던질 때 명시하는 경우 해당 내용이 대신 넘어갑니다.

이렇게 생성된 예외는 다음과 같이 사용할 수 있습니다.

```java
if(destination == null) {
    throw new OrderException(OrderErrorCode.ADDRESS_NOT_FOUND, "address is not found")
}
```

---

예외 헨들러는 전역에서 발생한 예외가 서블릿으로 가기 전 낚아채, 전처리합니다. 이는 구현 상세보단 기술적인 내용이 많으므로 인터넷 검색, AI 등을 활용해 기본 틀을 공부해 보시는 것을 추천드립니다.

다만, 예외 헨들러의 경우 응답 형식에 대한 추상화가 이루어지지 않아 아직 미구현 상태입니다.

