### PR TITLE
[#6][Feature] 응답 형식 정의

### DIFF
--- a/src/main/java/com/nbe8101team03/global/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/nbe8101team03/global/exception/handler/GlobalExceptionHandler.java
@@ -2,8 +2,10 @@ package com.nbe8101team03.global.exception.handler;
 
 
 import com.nbe8101team03.global.exception.exception.BaseException;
+import com.nbe8101team03.global.response.CommonResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -17,6 +19,10 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 @RequiredArgsConstructor
 public class GlobalExceptionHandler {
 
+    private ResponseEntity<Object> fail(String message, HttpStatus status) {
+        return ResponseEntity.status(status).body(CommonResponse.fail(message));
+    }
+
     //todo: 추후 환경 변수 주입으로 변경
     private boolean isDebug = true;
 
@@ -27,10 +33,19 @@ public class GlobalExceptionHandler {
             log.warn("{}", exception.getLogMessage());
         }
 
-        //todo: 추후 응답 형식 지정 이후 적절한 값으로 변경
-        return ResponseEntity.status(exception.getErrorCode().getHttpStatus())
-                .body(exception.getErrorCode());
+        return fail(exception.getMessage(), exception.getErrorCode().getHttpStatus());
+    }
 
+    /**
+     * 예상치 못한 예외를 정의합니다. 위 `handleBaseException` 의 경우, 사전에 정의된 예외를 잡아 처리하지만, 해당 메서드의 경우
+     * 정의되지 못한 예외가 발생하는 경우, 해당 예외를 그대로 클라이언트로 보내는 것이 아닌, 좀 더 "읽기 좋은" 형태로 가공합니다.
+     * @param ex
+     * @return
+     */
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<Object> handleUnexpectedException(Exception ex) {
+        log.error("[unexpected] {}", ex.getMessage(), ex);
+        return fail("unknown internal server error", HttpStatus.INTERNAL_SERVER_ERROR);
     }
 
 

--- a/src/main/java/com/nbe8101team03/global/response/CommonResponse.java
+++ b/src/main/java/com/nbe8101team03/global/response/CommonResponse.java
@@ -1,0 +1,53 @@
+package com.nbe8101team03.global.response;
+
+import lombok.Getter;
+
+
+/**
+ * 공통 응답 형식입니다. 모든 API 응답은 해당 객체로 래핑한 값이 와야 합니다.
+ * <pre>
+ *     {@code
+ *       return ResponseEntity.ok(CommonResponse.success(orderData);
+ *     }
+ * </pre>
+ * 와 같은 형식을 사용하여 반환할 수 있습니다.
+ * @param <T>
+ */
+@Getter
+public class CommonResponse<T> implements Response<T> {
+    private final String status;
+    private final T data;
+    private final String message;
+
+    protected CommonResponse(String status, T data, String message) {
+        this.status = status;
+        this.data = data;
+        this.message = message;
+    }
+
+    protected CommonResponse(String code, String status, T data, String message) {
+        this.status = status;
+        this.data = data;
+        this.message = message;
+    }
+
+    public static <T> CommonResponse<T> success(T data, String message) {
+        return new CommonResponse<>("success", data, message);
+    }
+
+    public static <T> CommonResponse<T> success(T data) {
+        return new CommonResponse<>("success", data, "success to response");
+    }
+
+    public static <T> CommonResponse<T> success() {
+        return new CommonResponse<>("success", null, "success to response");
+    }
+
+    public static <T> CommonResponse<T> fail(String message) {
+        return new CommonResponse<>("fail", null, message);
+    }
+
+    public static <T> CommonResponse<T> fail() {
+        return new CommonResponse<>("fail", null, "fail to response");
+    }
+}

--- a/src/main/java/com/nbe8101team03/global/response/Response.java
+++ b/src/main/java/com/nbe8101team03/global/response/Response.java
@@ -1,0 +1,9 @@
+package com.nbe8101team03.global.response;
+
+public interface Response<T> {
+    String getStatus();
+
+    T getData();
+
+    String getMessage();
+}


### PR DESCRIPTION


<!-- PR의 제목은 "[#이슈번호] [종류(ex.FEATURE)] 이슈이름" 으로 작성 -->

<!-- Auto close 할 이슈 번호 -->
- close #6

## ✨ 구현 기능 명세

모든 API 즉, 서버가 클라이언트로 요청을 보낼 때 받는 응답 구조를 정의하였습니다.
```json
{
        "status" : "success",
	"data" : {
			"data1" : " ~~ ",
			"data2" : " ~~ ",
			"data3" : " ~~ ",
	},
	"message" : "저장을 완료했습니다."
}
```
모든 응답은 다음과 같은 형식을 가집니다. 대부분의 API 응답은 `CommonResponse.success` 를 통해 이루어집니다.

```java
ResponseEntity<Response<OrderData>> getOrderData() {
    //~~~ 기타 로직
    return ResponseEntity.ok(CommonResponse.success(orderData);
}
```
와 같이 컨트롤러에서 반환을 한다면, orderData 에 따라 위 형식이 자동으로 작성되어 전송됩니다. 
이때, orderData 는 직렬화 가능한 객체여야 합니다.

주의할 점은, 해당 컨트롤러 메서드의 반환 타입이 `ResponseEntity<Response<[데이터에 들어올 클래스의 타입]>> 이 되어야 합니다. 가령, 리스트나 복잡한 자료형이 아닌, 단순히 Long 하나만 반환하고 싶다면 
```java
ResponseEntity<Response<Long>> getLong() {

    return ResponseEntity.ok(CommonResponse.success(3L);
}
```
와 같이 반환하면 됩니다. 

